### PR TITLE
Bump to Fedora 26

### DIFF
--- a/activity-build-docker/Dockerfile
+++ b/activity-build-docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:22
+FROM fedora:26
 
 RUN dnf install -y git gettext sugar-toolkit-gtk3 sugar-toolkit
 

--- a/aslo/api/gh.py
+++ b/aslo/api/gh.py
@@ -1,7 +1,6 @@
 import hmac
 import hashlib
 from flask import current_app as app
-from urllib.parse import urlparse
 from github import Github
 
 
@@ -16,11 +15,8 @@ def auth():
 
 
 def get_developers(repo_url):
-    o = urlparse(repo_url)
-    repo = o.path[1:].strip('.git')
-
     g = auth()
-    repository = g.get_repo(repo)
+    repository = g.get_repo(repo_url)
     contributors = repository.get_contributors()
     developers = []
     for c in contributors:

--- a/aslo/api/release.py
+++ b/aslo/api/release.py
@@ -316,7 +316,7 @@ def handle_release(gh_json):
         metadata['i18n_summary'] = {'en': metadata.get('summary', '')}
 
     metadata['repository'] = repo_url
-    metadata['developers'] = gh.get_developers(metadata['repository'])
+    metadata['developers'] = gh.get_developers(gh_json['repository']['full_name'])
     metadata['icon_bin'] = img.get_icon(repo_path, metadata['icon'])
 
     try:


### PR DESCRIPTION
This PR in response to the suggestion made by @Quozl. https://github.com/sugarlabs/sugar-toolkit-gtk3/issues/369

> When you use an old Fedora, we're more likely to say "upgrade" rather than do regression or bisection on such an old version of Sugar. Further back you go, the larger the bisection. Fedora 22 uses Sugar 0.104, Fedora 23 uses Sugar 0.106, Fedora 24 uses Sugar 0.108, Fedora 26 uses Sugar 0.110. From Fedora git.
With no clear plans for a Sugar 0.112 yet, my guess is Fedora 26 is adequate for the moment.

It's been tested with [following core activities](https://github.com/sugarlabs/sugar-build/blob/master/build/modules.json) and all except the last two https://github.com/sugarlabs-test/gtd-activity and https://github.com/sugarlabs-test/clock-web  build fine. Last two don't have any license field. 

<hr>
Also it removes the dependency on `strip` and `urlparse`, as it gave unexpected results it last character of repo matched `g` , `i` or `t`. 
Instead it uses JSON payload provided repo full_name.

Alternative is to use `replace` 
